### PR TITLE
Patch log4j2 dependency version

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -95,10 +95,10 @@ dependencies {
     compile group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '2.8.6'
 
     ////// Log4J
-    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.13.1'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.13.1'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.13.1'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-jul', version: '2.13.1'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.15.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.15.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.15.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-jul', version: '2.15.0'
 
     ///// JUnit 5
     testCompile "org.jetbrains.kotlin:kotlin-test"


### PR DESCRIPTION
Due to [CVE-2021-44228](https://www.lunasec.io/docs/blog/log4j-zero-day/), patching of dependency