### PR TITLE
Updating log4j to 2.16.0

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -95,10 +95,10 @@ dependencies {
     compile group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '2.8.6'
 
     ////// Log4J
-    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.15.0'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.15.0'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.15.0'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-jul', version: '2.15.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.16.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.16.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.16.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-jul', version: '2.16.0'
 
     ///// JUnit 5
     testCompile "org.jetbrains.kotlin:kotlin-test"


### PR DESCRIPTION
Since 2.15.0 apparently still has some issues.