### PR TITLE
Updated to log4j 2.17

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -30,7 +30,6 @@ configurations {
 
 repositories {
     mavenCentral()
-    maven { url "https://kotlin.bintray.com/kotlinx" }
 }
 
 compileKotlin {
@@ -47,6 +46,7 @@ dependencies {
     def jettyVersion = '9.4.44.v20210927'
     def alpnApiVersion = '1.1.3.v20160715'
     def alpnBootVersion = '8.1.12.v20180117'
+    def log4jVersion = '2.17.0'
 
     ///// Frontend files (produced by sub-project).
     implementation frontendClasspath(project(path: ":frontend", configuration: 'frontendFiles'))
@@ -63,7 +63,7 @@ dependencies {
     }
     compile group: 'io.swagger.core.v3', name: 'swagger-core', version: '2.1.5'
     compile group: 'org.webjars', name: 'swagger-ui', version: '3.24.3'
-    compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.12.+'
+    compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.13.0'
     compile group: 'io.github.classgraph', name: 'classgraph', version: '4.8.34'
     compile group: 'org.eclipse.jetty.http2', name: 'http2-server', version: jettyVersion
     compile group: 'org.eclipse.jetty', name: 'jetty-alpn-conscrypt-server', version: jettyVersion
@@ -95,10 +95,10 @@ dependencies {
     compile group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '2.8.6'
 
     ////// Log4J
-    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.16.0'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.16.0'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.16.0'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-jul', version: '2.16.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4jVersion
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: log4jVersion
+    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: log4jVersion
+    compile group: 'org.apache.logging.log4j', name: 'log4j-jul', version: log4jVersion
 
     ///// JUnit 5
     testCompile "org.jetbrains.kotlin:kotlin-test"


### PR DESCRIPTION
Addressing [CVE-2021-45105](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105)