### PR TITLE
Hotfix: Multi target task frontend crash

### DIFF
--- a/backend/src/main/kotlin/dev/dres/DRES.kt
+++ b/backend/src/main/kotlin/dev/dres/DRES.kt
@@ -42,7 +42,7 @@ import kotlin.system.exitProcess
  */
 object DRES {
     /** Version of DRES. */
-    const val VERSION = "2.0.1"
+    const val VERSION = "2.0.2"
 
     /** Application root; should be relative to JAR file or classes path. */
     val APPLICATION_ROOT: Path =

--- a/doc/oas-client.json
+++ b/doc/oas-client.json
@@ -2,8 +2,8 @@
   "openapi" : "3.0.3",
   "info" : {
     "title" : "DRES Client API",
-    "version" : "2.0.1",
-    "description" : "Client API for DRES (Distributed Retrieval Evaluation Server), Version 2.0.1"
+    "version" : "2.0.2",
+    "description" : "Client API for DRES (Distributed Retrieval Evaluation Server), Version 2.0.2"
   },
   "paths" : {
     "/api/v2/client/evaluation/currentTask/{evaluationId}" : {

--- a/doc/oas.json
+++ b/doc/oas.json
@@ -2,8 +2,8 @@
   "openapi" : "3.0.3",
   "info" : {
     "title" : "DRES API",
-    "version" : "2.0.1",
-    "description" : "API for DRES (Distributed Retrieval Evaluation Server), Version 2.0.1",
+    "version" : "2.0.2",
+    "description" : "API for DRES (Distributed Retrieval Evaluation Server), Version 2.0.2",
     "contact" : {
       "name" : "The DRES Dev Team",
       "url" : "https://dres.dev"

--- a/frontend/src/app/services/pipes/filter-not-in.pipe.ts
+++ b/frontend/src/app/services/pipes/filter-not-in.pipe.ts
@@ -18,7 +18,7 @@ export class FilterNotInPipe implements PipeTransform {
   transform(value: any[], haystack: any[], propertyKey : string = null): any[] {
     if(value){
       if(propertyKey){
-       return value.filter(it => !haystack.map(item => item[propertyKey]).includes(it[propertyKey]))
+       return value.filter(it => !haystack.map(item => item != null && item[propertyKey]).includes(it[propertyKey]))
       }
       return value.filter(it => !haystack.includes(it));
     }else{


### PR DESCRIPTION
Fixes an annoying bug which was caused by multi-target task templates.
The frontend ceased to work properly when adding multiple targets without saving in between.